### PR TITLE
Implementation of finish screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@
 # Mono auto generated files
 mono_crash.*
 
+# User-specific lsp files
+._* 
+
 # Build results
 [Dd]ebug/
 [Dd]ebugPublic/

--- a/CHIPSZ/Program.cs
+++ b/CHIPSZ/Program.cs
@@ -69,7 +69,7 @@ namespace CHIPSZ
             Hand hand = Input.Hand(Handed.Right);
             Vec3 handPreviousFrame;
             Vec3 scoreTextPos = new Vec3(-1.0f, 0.9f, -2.0f);
-            while (SK.Step(() => 
+            while (!finishScreen.IsExit() && SK.Step(() => 
             {
                 handPreviousFrame = hand.palm.position;
                 hand = Input.Hand(Handed.Right);
@@ -188,14 +188,8 @@ namespace CHIPSZ
                 if (countdown.GetDuration() <= 0)
                 {
                     finishScreen.Update();
-                    if(finishScreen.OptionSelected() && finishScreen.IsReset())
-                    {
-                        Initialise();
-                    }
-                    else if (finishScreen.OptionSelected() && finishScreen.IsExit())
-                    {
-                    }
-
+                    if(finishScreen.OptionSelected() && finishScreen.IsReset()) Initialise(); 
+                   
                 }
             })) ;
             SK.Shutdown();

--- a/CHIPSZ/Program.cs
+++ b/CHIPSZ/Program.cs
@@ -5,6 +5,7 @@ using CHIPSZClassLibrary;
 using System.Threading;
 using System.Runtime.CompilerServices;
 using Windows.Media.Core;
+using Windows.UI.Xaml.Documents;
 
 namespace CHIPSZ
 {
@@ -187,6 +188,13 @@ namespace CHIPSZ
                 if (countdown.GetDuration() <= 0)
                 {
                     finishScreen.Update();
+                    if(finishScreen.OptionSelected() && finishScreen.IsReset())
+                    {
+                        Initialise();
+                    }
+                    else if (finishScreen.OptionSelected() && finishScreen.IsExit())
+                    {
+                    }
 
                 }
             })) ;

--- a/CHIPSZ/Program.cs
+++ b/CHIPSZ/Program.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using CHIPSZClassLibrary;
 using System.Threading;
+using System.Runtime.CompilerServices;
 
 namespace CHIPSZ
 {
@@ -13,6 +14,7 @@ namespace CHIPSZ
         private static TargetGenerator targetGenerator;
         private static Floor floor;
 		private static StartingScreen screen;
+        private static FinishScreen finishScreen;
 
         public static Vec3 GetVelocity(Vec3 currentPos, Vec3 prevPos)
         {
@@ -41,6 +43,7 @@ namespace CHIPSZ
             countdown.SetRunning(false);
             floor = new Floor();
 			screen = new StartingScreen();
+            finishScreen = new FinishScreen();
 
             ballGenerator = new ProjectileGenerator();
             targetGenerator = new TargetGenerator();
@@ -60,7 +63,7 @@ namespace CHIPSZ
             Hand hand = Input.Hand(Handed.Right);
             Vec3 handPreviousFrame;
             Vec3 scoreTextPos = new Vec3(-1.0f, 0.9f, -2.0f);
-            while (countdown.GetDuration() > 0.0 && SK.Step(() => // when the time runs out the app closes
+            while (SK.Step(() => 
             {
                 handPreviousFrame = hand.palm.position;
                 hand = Input.Hand(Handed.Right);
@@ -176,6 +179,11 @@ namespace CHIPSZ
                     }
                 }
                 countdown.Update();
+                if (countdown.GetDuration() <= 0)
+                {
+                    finishScreen.Update();
+
+                }
             })) ;
             SK.Shutdown();
         }

--- a/CHIPSZ/Program.cs
+++ b/CHIPSZ/Program.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using CHIPSZClassLibrary;
 using System.Threading;
 using System.Runtime.CompilerServices;
+using Windows.Media.Core;
 
 namespace CHIPSZ
 {
@@ -12,9 +13,12 @@ namespace CHIPSZ
         private static Countdown countdown;
         private static ProjectileGenerator ballGenerator;
         private static TargetGenerator targetGenerator;
+        private static TargetGenerator demoTargets;
         private static Floor floor;
 		private static StartingScreen screen;
         private static FinishScreen finishScreen;
+        private static AudioManager audioManager;
+        private static GameTimer spawnBallTimer;
 
         public static Vec3 GetVelocity(Vec3 currentPos, Vec3 prevPos)
         {
@@ -26,9 +30,22 @@ namespace CHIPSZ
             return Math.Sqrt((velocity.x * velocity.x) + (velocity.y * velocity.y) + (velocity.z * velocity.z));
         }
 
+        public static void Initialise()
+        {
+            audioManager = new AudioManager();
+            countdown = new Countdown(5); // sets the game duration to 90 seconds
+            countdown.SetRunning(false);
+            floor = new Floor();
+            screen = new StartingScreen();
+            finishScreen = new FinishScreen();
+            ballGenerator = new ProjectileGenerator();
+            targetGenerator = new TargetGenerator();
+            demoTargets = new TargetGenerator();
+            spawnBallTimer = new GameTimer(0.5);
+        }
+
         static void Main(string[] args)
         {
-            AudioManager audioManager = new AudioManager();
 
             // Initialize StereoKit
             SKSettings settings = new SKSettings
@@ -39,19 +56,7 @@ namespace CHIPSZ
             if (!SK.Initialize(settings))
                 Environment.Exit(1);
 
-            countdown = new Countdown(90); // sets the game duration to 90 seconds
-            countdown.SetRunning(false);
-            floor = new Floor();
-			screen = new StartingScreen();
-            finishScreen = new FinishScreen();
-
-            ballGenerator = new ProjectileGenerator();
-            targetGenerator = new TargetGenerator();
-            TargetGenerator demoTargets = new TargetGenerator();
-
-
-            GameTimer spawnBallTimer = new GameTimer(0.5);           
-
+            Initialise();
             // Core application loop
             //while (countdown.IsRunning() && SK.Step(() => // when the time runs out the app closes
             //booleans to switch between game and demo states

--- a/CHIPSZClassLibrary/CHIPSZClassLibrary.csproj
+++ b/CHIPSZClassLibrary/CHIPSZClassLibrary.csproj
@@ -133,6 +133,7 @@
     <Compile Include="GameTimer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="StartingScreen.cs" />
+    <Compile Include="FinishScreen.cs" />
     <Compile Include="Target.cs" />
     <Compile Include="TargetGenerator.cs" />
     <Compile Include="WaterProjectile.cs" />

--- a/CHIPSZClassLibrary/FinishScreen.cs
+++ b/CHIPSZClassLibrary/FinishScreen.cs
@@ -1,16 +1,11 @@
 ﻿using StereoKit;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel.Design;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+
 
 namespace CHIPSZ
 {          
     // TODO: Style header, body and buttons
 
-    internal class FinishScreen
+    public class FinishScreen
     {
         private Pose finishPose;
         private Pose statisticsPose;

--- a/CHIPSZClassLibrary/FinishScreen.cs
+++ b/CHIPSZClassLibrary/FinishScreen.cs
@@ -1,28 +1,39 @@
 ﻿using StereoKit;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 
-namespace CHIPSZClassLibrary
+namespace CHIPSZ
 {
-  public class FinishScreen
-  {
+    internal class FinishScreen
+    {
+        private Pose finishPose;
 
-    private Pose finishPose;
+        public FinishScreen()
+        {
+            finishPose = new Pose(new Vec3(0, .2f, -.3f), Quat.LookDir(0, 0, 1));
+        }
 
-    public FinishScreen() {
-      finishPose = new Pose(new Vec3(0, .2f, -.3f), Quat.LookDir(1, 0, 1));
+        public void Update()
+        {
+            GameOverScreen();
+        }
+
+        // Initial Screen where the user will be prompt after the timer runs out
+        public void GameOverScreen()
+        {
+            UI.WindowBegin("", ref finishPose, new Vec2(20, 10) * U.cm, UIWin.Body);
+            UI.PopTextStyle();
+            UI.Text("Game Over", TextAlign.Center);
+            UI.HSeparator();
+            UI.Button("Try again");
+            UI.Button("See game statistics");
+            UI.Button("Leave the game");
+            UI.WindowEnd();
+        }
+
     }
-
-    public void Update() {
-      GameOverScreen();
-    }
-
-    // Initial Screen where the user will be prompt after the timer runs out
-    public void GameOverScreen() {
-      UI.WindowBegin("\tGame Over", ref finishPose, new Vec2(20, 10) * U.cm, UIWin.Normal);
-      UI.WindowEnd();
-    }
-
-  }
 }
-
-
 

--- a/CHIPSZClassLibrary/FinishScreen.cs
+++ b/CHIPSZClassLibrary/FinishScreen.cs
@@ -7,10 +7,14 @@ using System.Text;
 using System.Threading.Tasks;
 
 namespace CHIPSZ
-{
+{          
+    // TODO: Style header, body and buttons
+
     internal class FinishScreen
     {
         private Pose finishPose;
+        private Pose statisticsPose;
+
         private bool reset = false;
         private bool statistics = false;
         private bool exit = false;
@@ -19,6 +23,8 @@ namespace CHIPSZ
         public FinishScreen()
         {
             finishPose = new Pose(new Vec3(0, .2f, -.3f), Quat.LookDir(0, 0, 1));
+            statisticsPose = new Pose(new Vec3(0, .2f, -.3f), Quat.LookDir(0, 1, 1));
+
         }
 
         public void Update()
@@ -34,8 +40,9 @@ namespace CHIPSZ
         public void GameOverScreen()
         {
             UI.WindowBegin("", ref finishPose, new Vec2(20, 10) * U.cm, UIWin.Body);
-            UI.PopTextStyle();
+           // UI.PushTextStyle(HeaderStyle());
             UI.Text("Game Over", TextAlign.Center);
+            //UI.PopTextStyle();
             UI.HSeparator();
             if (UI.Button("Try again")) reset = true;
             if (UI.Button("See game statistics")) statistics = true;
@@ -50,13 +57,29 @@ namespace CHIPSZ
 
         public void StatisticsScreen()
         {
+            UI.WindowBegin("Your Performance", ref finishPose, new Vec2(35, 0) * U.cm, UIWin.Normal); 
 
+            UI.WindowEnd();
         }
 
         public void Exit()
         {
 
         }
+
+       // public TextStyle HeaderStyle()
+       // {
+           // return Text.MakeStyle(Font.Default, 30, Color.Hex(0xDE0025));
+        //}
+
+       // public TextStyle BodyStyle()
+       // {
+       //     return new TextStyle();
+       // }
+       // public TextStyle ButtonStyle()
+       // {
+      //      return new TextStyle();
+       // }
 
         public bool OptionSelected()
         {

--- a/CHIPSZClassLibrary/FinishScreen.cs
+++ b/CHIPSZClassLibrary/FinishScreen.cs
@@ -1,0 +1,28 @@
+﻿using StereoKit;
+
+namespace CHIPSZClassLibrary
+{
+  public class FinishScreen
+  {
+
+    private Pose finishPose;
+
+    public FinishScreen() {
+      finishPose = new Pose(new Vec3(0, .2f, -.3f), Quat.LookDir(1, 0, 1));
+    }
+
+    public void Update() {
+      GameOverScreen();
+    }
+
+    // Initial Screen where the user will be prompt after the timer runs out
+    public void GameOverScreen() {
+      UI.WindowBegin("\tGame Over", ref finishPose, new Vec2(20, 10) * U.cm, UIWin.Normal);
+      UI.WindowEnd();
+    }
+
+  }
+}
+
+
+

--- a/CHIPSZClassLibrary/FinishScreen.cs
+++ b/CHIPSZClassLibrary/FinishScreen.cs
@@ -1,6 +1,7 @@
 ﻿using StereoKit;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.Design;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -10,6 +11,10 @@ namespace CHIPSZ
     internal class FinishScreen
     {
         private Pose finishPose;
+        private bool reset = false;
+        private bool statistics = false;
+        private bool exit = false;
+        
 
         public FinishScreen()
         {
@@ -18,7 +23,11 @@ namespace CHIPSZ
 
         public void Update()
         {
-            GameOverScreen();
+            if (!OptionSelected()) GameOverScreen();
+            else if (reset) StartScreen();
+            else if (statistics) StatisticsScreen();
+            else Exit();
+            
         }
 
         // Initial Screen where the user will be prompt after the timer runs out
@@ -28,12 +37,35 @@ namespace CHIPSZ
             UI.PopTextStyle();
             UI.Text("Game Over", TextAlign.Center);
             UI.HSeparator();
-            UI.Button("Try again");
-            UI.Button("See game statistics");
-            UI.Button("Leave the game");
+            if (UI.Button("Try again")) reset = true;
+            if (UI.Button("See game statistics")) statistics = true;
+            if (UI.Button("Leave the game")) exit = true;
             UI.WindowEnd();
         }
 
+        public void StartScreen()
+        {
+
+        }
+
+        public void StatisticsScreen()
+        {
+
+        }
+
+        public void Exit()
+        {
+
+        }
+
+        public bool OptionSelected()
+        {
+            return reset || statistics || exit;
+        }
+
+
+
+        
+
     }
 }
-

--- a/CHIPSZClassLibrary/FinishScreen.cs
+++ b/CHIPSZClassLibrary/FinishScreen.cs
@@ -35,9 +35,7 @@ namespace CHIPSZ
         public void GameOverScreen()
         {
             UI.WindowBegin("", ref finishPose, new Vec2(20, 10) * U.cm, UIWin.Body);
-           // UI.PushTextStyle(HeaderStyle());
             UI.Text("Game Over", TextAlign.Center);
-            //UI.PopTextStyle();
             UI.HSeparator();
             if (UI.Button("Try again")) reset = true;
             if (UI.Button("See game statistics")) statistics = true;
@@ -45,41 +43,27 @@ namespace CHIPSZ
             UI.WindowEnd();
         }
 
-        public void StartScreen()
+        private void StartScreen()
         {
 
         }
 
-        public void StatisticsScreen()
+        private void StatisticsScreen()
         {
             UI.WindowBegin("Your Performance", ref finishPose, new Vec2(35, 0) * U.cm, UIWin.Normal); 
 
             UI.WindowEnd();
         }
 
-        public void Exit()
+        private void Exit()
         {
 
         }
 
-       // public TextStyle HeaderStyle()
-       // {
-           // return Text.MakeStyle(Font.Default, 30, Color.Hex(0xDE0025));
-        //}
-
-       // public TextStyle BodyStyle()
-       // {
-       //     return new TextStyle();
-       // }
-       // public TextStyle ButtonStyle()
-       // {
-      //      return new TextStyle();
-       // }
-
-        public bool OptionSelected()
-        {
-            return reset || statistics || exit;
-        }
+        public bool OptionSelected() =>  reset || statistics || exit;
+        
+        public bool IsReset() => reset;
+        public bool IsExit() => exit;
 
 
 


### PR DESCRIPTION
When the time runs out, the finish screen will be rendered, at this stage only has three options:
1. reset the game
    - resets the game by defaulting the static variables
2. go to statistics screen
    - if the "see statistics" button is pressed, it goes to the statistics screen (empty window with a header)
    - I was thinking of some way to organise the screens better so we do not have 2 screens in one class
4. leave the game
     - when the "quit the game" button is pressed, finishScreen sets the flag exit, which leaves the game.